### PR TITLE
Fixed wrong pattern for detecting whether slapd is active

### DIFF
--- a/slapdadm
+++ b/slapdadm
@@ -369,7 +369,7 @@ sub stopSlapd {
   } else {
     my $out = `service $serviceName status`;
     chomp($out);
-    if ($out !~ /is not running/i) {
+    if ($out !~ /inactive/i) {
       die("slapd seems to be running ($out)\n");
     }
   }


### PR DESCRIPTION
When checking the status of slapd service on ubuntu 16.04 LTS (Openldap 2.4.42) for instance, the output looks like this:
```
$ systemctl status slapd

* slapd.service - LSB: OpenLDAP standalone server (Lightweight Directory Access Protocol)
   Loaded: loaded (/etc/init.d/slapd; bad; vendor preset: enabled)
   Active: inactive (dead) since Wed 2017-12-13 18:38:48 CET; 38min ago
     Docs: man:systemd-sysv-generator(8)
  Process: 12234 ExecStop=/etc/init.d/slapd stop (code=exited, status=0/SUCCESS)
```

So there is no such string as "is not running" which is currently used by slapadm to check the status. Replaced with "inactive".